### PR TITLE
Fix description field

### DIFF
--- a/src/actions/hobbyActions.js
+++ b/src/actions/hobbyActions.js
@@ -41,7 +41,7 @@ const fetchHobbies = () => ({
   [API]: {
     types: [FETCH_HOBBIES, FETCH_HOBBIES_SUCCESS, FETCH_HOBBIES_FAILURE],
     method: GET,
-    url: `${API_URL}hobbies/`
+    url: `${API_URL}hobbies/?editable_only=true`
   }
 });
 

--- a/src/actions/promotionActions.js
+++ b/src/actions/promotionActions.js
@@ -29,7 +29,7 @@ const fetchPromotions = () => ({
       FETCH_PROMOTIONS_FAILURE
     ],
     method: GET,
-    url: `${API_URL}promotions/`
+    url: `${API_URL}promotions/?editable_only=true`
   }
 });
 

--- a/src/components/views/HobbyListView.jsx
+++ b/src/components/views/HobbyListView.jsx
@@ -6,6 +6,7 @@ import ActionCreators from '../../actions';
 import HobbyListItem from '../blocks/HobbyListItem';
 import { makeStyles } from '@material-ui/styles';
 import hplogo from '../../img/hp-logo-500x500.png'
+import { usePositiveEffect } from '../../hooks';
 
 const useStyles = makeStyles({
   addHobbyContainer: {
@@ -20,6 +21,7 @@ const HobbyListView = () => {
   const dispatch = useDispatch();
   const hobbyState = useSelector(state => state.hobbies);
   const classes = useStyles();
+  const accessToken = useSelector(state => state.auth.accessToken);
   const hobbyDeleteHandler = hobby_id => event => {
     dispatch(ActionCreators.deleteHobby(hobby_id));
   };
@@ -35,10 +37,10 @@ const HobbyListView = () => {
     />
   ));
 
-  useEffect(() => {
+  usePositiveEffect(() => {
     // initial data fetch
     dispatch(ActionCreators.fetchHobbies());
-  }, [dispatch]);
+  }, [accessToken]);
 
   return (
     <Container maxWidth="sm">

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -38,6 +38,11 @@ export function useDeepCompareMemoize(value) {
   return ref.current;
 }
 
+export function usePositiveEffect(callback, dependencies) {
+  if (dependencies.includes(undefined)) callback = e => e;
+  useDeepCompareEffect(callback, dependencies);
+}
+
 export function useDeepCompareEffect(callback, dependencies) {
   useEffect(callback, useDeepCompareMemoize(dependencies));
 }

--- a/src/reducers/formReducer.js
+++ b/src/reducers/formReducer.js
@@ -22,7 +22,7 @@ const INITIAL_STATE = {
     name: null,
     location: null,
     cover_image: null,
-    description: null,
+    description: '',
     organizer: null,
     categories: []
   },
@@ -32,7 +32,7 @@ const INITIAL_STATE = {
     name: null,
     location: null,
     cover_image: null,
-    description: null,
+    description: '',
     organizer: null,
     available_count: null
   }


### PR DESCRIPTION
Change description field in formReducer's initial state to be an empty string instead of `null`, as backend rejects null values.