### PR TITLE
Send coordinates only if both fields filled

### DIFF
--- a/src/components/blocks/LocationModalButton.jsx
+++ b/src/components/blocks/LocationModalButton.jsx
@@ -22,11 +22,7 @@ const LocationModalButton = () => {
     name: '',
     address: '',
     zip_code: '',
-    city: '',
-    coordinates: {
-      latitude: 0.0,
-      longitude: 0.0
-    }
+    city: ''
   });
 
   const classes = useStyles();
@@ -38,15 +34,21 @@ const LocationModalButton = () => {
       name: locationData.name,
       address: locationData.address,
       zip_code: locationData.zip_code,
-      city: locationData.city,
-      coordinates: {
+      city: locationData.city
+    };
+    if (
+      locationData.coordinates &&
+      locationData.coordinates.latitude &&
+      locationData.coordinates.longitude
+    ) {
+      locationFormData.coordinates = {
         type: 'Point',
         coordinates: [
           parseFloat(locationData.coordinates.latitude),
           parseFloat(locationData.coordinates.longitude)
         ]
-      }
-    };
+      };
+    }
     dispatch(ActionCreators.createLocation(locationFormData));
     setOpen(false);
   };


### PR DESCRIPTION
- Prevents sending default values for coordinates on location post, if both latitude and longitude not set
- Allows backend to calculate location based on street address for location with no hand filled coordinates